### PR TITLE
Disable double encoding by default

### DIFF
--- a/src/WordpressBlade.php
+++ b/src/WordpressBlade.php
@@ -34,7 +34,9 @@ class WordpressBlade extends Blade
 
     public static function create($viewPath, string $cachePath, $componentPath = null)
     {
-        return new self($viewPath, $cachePath, $componentPath);
+        return tap(new self($viewPath, $cachePath, $componentPath), function ($blade) {
+            $blade->compiler()->withoutDoubleEncoding();
+        });
     }
 
     public static function getInstance()


### PR DESCRIPTION
Causes format issues for values stored in the database already encoded

Can still be enabled if desired by calling `->compiler()->withDoubleEncoding()` after creating an instance.