### PR TITLE
Add renders blade trait

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -6,10 +6,12 @@ use Illuminate\View\Component as BaseComponent;
 
 abstract class Component extends BaseComponent
 {
+    use RendersBlade;
+
     protected function view($view = null, $data = [], $mergeData = [])
     {
         $data = array_merge($data, $this->data());
 
-        return WordpressBlade::getInstance()->make($view, $data, $mergeData);
+        return $this->blade()->make($view, $data, $mergeData);
     }
 }

--- a/src/RendersBlade.php
+++ b/src/RendersBlade.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace StarringJane\WordpressBlade;
+
+trait RendersBlade
+{
+    protected function blade()
+    {
+        return WordpressBlade::getInstance();
+    }
+
+    protected function view($view = null, $data = [], $mergeData = [])
+    {
+        return $this->blade()->make($view, $data, $mergeData);
+    }
+}


### PR DESCRIPTION
This trait will allow this package to be more reusable for others.
You can render blade views or components in other classes than a component by including the trait.

Example below when registering a custom ACF Gutenberg block:
```php
<?php

class CustomBlock extends Block
{
    use RendersBlade;

    //...

    public function render()
    {
        return $this->view('custom');
    }
}
```